### PR TITLE
Updated README.md for being able to successfully build on Linux Mint 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,11 @@ See [LICENSE](LICENSE).
 
   
 
-- For Linux Mint 18 "Sarah" - Cinnamon x64
+- For Linux Mint 19 "Tarah" - Cinnamon x64
 
   
 
-`sudo apt install qml-module-qt-labs-settings qml-module-qtgraphicaleffects`
+`sudo apt-get install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-dialogs qml-module-qt-labs-settings libqt5qml-graphicaleffects libreadline-dev`
 
   
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ See [LICENSE](LICENSE).
 
   
 
-`sudo apt-get install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-dialogs qml-module-qt-labs-settings libqt5qml-graphicaleffects libreadline-dev`
+`sudo apt-get install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-dialogs qml-module-qt-labs-settings qml-module-qtgraphicaleffects libreadline-dev`
 
   
 


### PR DESCRIPTION
I am not 100% sure if all these dependencies are absolutely necessary to successfully build on Mint 19, but I have tested the change on a Mint freshly installed in a VM and it works.
libreadline-dev is absolutely necessary though I cannot find it on the original Monero README.md. It will not compile without it, complaining that ld -lreadline not found.